### PR TITLE
Add polling and test it

### DIFF
--- a/src/flexmeasures_client/client.py
+++ b/src/flexmeasures_client/client.py
@@ -25,7 +25,8 @@ class FlexmeasuresClient:
     version: str = "/v3_0/"
     path: str = f"/api{version}"
 
-    request_timeout: float = 200.0  # seconds
+    polling_timeout: float = 200.0  # seconds
+    request_timeout: float = 20.0  # seconds
     request_step: float = 10  # seconds
     session: ClientSession | None = None
 
@@ -58,33 +59,34 @@ class FlexmeasuresClient:
             "Scheduling job waiting" in y.get("message", "") or "Scheduling job in progress" in y.get("message", "")
         )
 
-        while True:
-            try:
-                async with async_timeout.timeout(self.request_timeout):
-                    response = await self.session.request(
-                        method=method,
-                        url=url,
-                        params=params,
-                        headers=headers,
-                        json=json,
-                        ssl=False if "localhost" in self.host else True,
-                    )
-                    payload = await response.json()
-                    response.raise_for_status()
-                    break
-            except asyncio.TimeoutError as exception:
-                msg = "Timeout occurred while connecting to the API."
-                raise ConnectionError(
-                    msg,
-                ) from exception
-            except (ClientError, socket.gaierror) as exception:
-                if retry_function(exception, payload):
-                    await asyncio.sleep(self.request_step)
-                else:
-                    msg = "Error occurred while communicating with the API."
+        async with async_timeout.timeout(self.polling_timeout):
+            while True:
+                try:
+                    async with async_timeout.timeout(self.request_timeout):
+                        response = await self.session.request(
+                            method=method,
+                            url=url,
+                            params=params,
+                            headers=headers,
+                            json=json,
+                            ssl=False if "localhost" in self.host else True,
+                        )
+                        payload = await response.json()
+                        response.raise_for_status()
+                        break
+                except asyncio.TimeoutError as exception:
+                    msg = "Timeout occurred while connecting to the API."
                     raise ConnectionError(
                         msg,
                     ) from exception
+                except (ClientError, socket.gaierror) as exception:
+                    if retry_function(exception, payload):
+                        await asyncio.sleep(self.request_step)
+                    else:
+                        msg = "Error occurred while communicating with the API."
+                        raise ConnectionError(
+                            msg,
+                        ) from exception
 
         content_type = response.headers.get("Content-Type", "")
         if "application/json" not in content_type:

--- a/src/flexmeasures_client/client.py
+++ b/src/flexmeasures_client/client.py
@@ -30,7 +30,7 @@ class FlexmeasuresClient:
     max_polling_steps: int = 10  # seconds
     polling_timeout: float = 200.0  # seconds
     request_timeout: float = 20.0  # seconds
-    polling_delay: float = 10  # seconds
+    polling_interval: float = 10  # seconds
     session: ClientSession | None = None
 
     async def close(self):
@@ -91,17 +91,17 @@ class FlexmeasuresClient:
                             break
                     except asyncio.TimeoutError:
                         print(
-                            f"Client request timeout occurred while connecting to the API. Retrying in {self.polling_delay} seconds..."
+                            f"Client request timeout occurred while connecting to the API. Retrying in {self.polling_interval} seconds..."
                         )
                         polling_step += 1
-                        await asyncio.sleep(self.polling_delay)
+                        await asyncio.sleep(self.polling_interval)
                     except (ClientError, socket.gaierror) as exception:
                         if retry_function(exception, payload):
                             print(
-                                f"Server indicated to try again later. Retrying in {self.polling_delay} seconds..."
+                                f"Server indicated to try again later. Retrying in {self.polling_interval} seconds..."
                             )
                             polling_step += 1
-                            await asyncio.sleep(self.polling_delay)
+                            await asyncio.sleep(self.polling_interval)
                         else:
                             raise ConnectionError(
                                 "Error occurred while communicating with the API."

--- a/src/flexmeasures_client/client.py
+++ b/src/flexmeasures_client/client.py
@@ -20,9 +20,9 @@ class FlexmeasuresClient:
     password: str
     email: str
     access_token: str = None
-    scheme: str = "http"
     host: str = "localhost:5000"
-    local: bool = False
+    scheme: str = "http" if "localhost" in host else "https"
+    ssl: bool = False if "localhost" in host else True
     api_version: str = "v3_0"
     path: str = f"/api/{api_version}/"
     consumption_price_sensor: int = 3
@@ -84,7 +84,7 @@ class FlexmeasuresClient:
                                 params=params,
                                 headers=headers,
                                 json=json,
-                                ssl=False if "localhost" in self.host else True,
+                                ssl=self.ssl,
                             )
                             payload = await response.json()
                             response.raise_for_status()

--- a/src/flexmeasures_client/client.py
+++ b/src/flexmeasures_client/client.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import socket
 from dataclasses import dataclass
-from json import loads
 from typing import Any, cast
 
 import async_timeout
@@ -67,12 +66,11 @@ class FlexmeasuresClient:
         if self.session is None:
             self.session = ClientSession()
 
-        client_should_retry = lambda exception, payload: getattr(
-            exception, "status"
-        ) == 400 and (
-            "Scheduling job waiting" in payload.get("message", "")
-            or "Scheduling job in progress" in payload.get("message", "")
-        )
+        def client_should_retry(exception, payload) -> bool:
+            return getattr(exception, "status") == 400 and (
+                "Scheduling job waiting" in payload.get("message", "")
+                or "Scheduling job in progress" in payload.get("message", "")
+            )
 
         polling_step = 0
         try:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -160,7 +160,11 @@ async def test_get_schedule_timeout() -> None:
             repeat=True,
         )
         flexmeasures_client = FlexmeasuresClient(
-            "test", "test", polling_timeout=0.5, request_timeout=0.2, polling_interval=0.1
+            "test",
+            "test",
+            polling_timeout=0.5,
+            request_timeout=0.2,
+            polling_interval=0.1,
         )
 
         sensor_id = 1

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -84,6 +84,7 @@ async def test_trigger_schedule() -> None:
                     "datetime": "2023-03-03T11:00+02:00",
                 }
             ],
+            consumption_price_sensor=3,
         )
 
         m.assert_called_once_with(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -131,7 +131,7 @@ async def test_get_schedule() -> None:
             },
         )
         flexmeasures_client = FlexmeasuresClient(
-            "test", "test", request_timeout=2, polling_delay=0.2
+            "test", "test", request_timeout=2, polling_interval=0.2
         )
 
         sensor_id = 1
@@ -160,7 +160,7 @@ async def test_get_schedule_timeout() -> None:
             repeat=True,
         )
         flexmeasures_client = FlexmeasuresClient(
-            "test", "test", polling_timeout=0.5, request_timeout=0.2, polling_delay=0.1
+            "test", "test", polling_timeout=0.5, request_timeout=0.2, polling_interval=0.1
         )
 
         sensor_id = 1

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,5 +1,6 @@
+import asyncio
 import pytest
-from aioresponses import aioresponses
+from aioresponses import aioresponses, CallbackResult
 from flexmeasures_client.client import FlexmeasuresClient
 
 
@@ -35,7 +36,9 @@ async def test_post_measurements() -> None:
         values = "test"
         unit = "test"
 
-        await flexmeasures_client.post_measurements(sensor_id, start, duration, values, unit)
+        await flexmeasures_client.post_measurements(
+            sensor_id, start, duration, values, unit
+        )
     await flexmeasures_client.close()
 
 
@@ -53,22 +56,49 @@ async def test_get_schedule() -> None:
             "http://localhost:5000/api/v3_0/sensors/1/schedules/some-uuid",
             status=200,
             payload={
-                "values": [
-                    2.15,
-                    3,
-                    2
-                ],
+                "values": [2.15, 3, 2],
                 "start": "2015-06-02T10:00:00+00:00",
                 "duration": "PT45M",
-                "unit": "MW"
+                "unit": "MW",
             },
         )
-        flexmeasures_client = FlexmeasuresClient("test", "test", request_timeout=2, request_step=0.2)
+        flexmeasures_client = FlexmeasuresClient(
+            "test", "test", request_timeout=2, polling_delay=0.2
+        )
 
         sensor_id = 1
         schedule_id = "some-uuid"
         duration = "PT45M"
 
-        schedule, status = await flexmeasures_client.get_schedule(sensor_id, schedule_id, duration)
+        schedule, status = await flexmeasures_client.get_schedule(
+            sensor_id, schedule_id, duration
+        )
     assert schedule["values"] == [2.15, 3, 2]
+    await flexmeasures_client.close()
+
+
+@pytest.mark.asyncio
+async def test_get_schedule_timeout() -> None:
+    async def callback(url, **kwargs):
+        # Sleep longer than the polling_timeout
+        await asyncio.sleep(3)
+        return CallbackResult(status=200)
+
+    with aioresponses() as m:
+        m.get(
+            "http://localhost:5000/api/v3_0/sensors/1/schedules/some-uuid",
+            status=408,
+            callback=callback,
+            repeat=True,
+        )
+        flexmeasures_client = FlexmeasuresClient(
+            "test", "test", polling_timeout=0.5, request_timeout=0.2, polling_delay=0.1
+        )
+
+        sensor_id = 1
+        schedule_id = "some-uuid"
+        duration = "PT45M"
+
+        with pytest.raises(ConnectionError):
+            await flexmeasures_client.get_schedule(sensor_id, schedule_id, duration)
     await flexmeasures_client.close()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -16,6 +16,7 @@ async def test_get_access_token() -> None:
 
         await flexmeasures_client.get_access_token()
         assert flexmeasures_client.access_token == "test-token"
+    await flexmeasures_client.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
I implemented basic polling. Follow-ups:
- [ ] The test depends on unmerged aioresponses functionality -> see https://github.com/pnuckowski/aioresponses/pull/237.
- [ ] Move to a more elegant step function (increasing steps) -> see Issue #3.
- [ ] There is no HTTP status code to convey "please retry later", but there *is* a dedicated header that the client could listen to instead: [Retry-After](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After). I'd rather move to having FlexMeasures server use this, instead of moving the client's polling logic to the `get_schedule` method. I kind of like that the polling logic is implemented on all requests to FlexMeasures whose responses indicate to retry the request later. -> see https://github.com/FlexMeasures/flexmeasures/issues/645