### PR TITLE
feat: clarify return types

### DIFF
--- a/src/flexmeasures_client/client.py
+++ b/src/flexmeasures_client/client.py
@@ -290,7 +290,12 @@ class FlexMeasuresClient:
         """Get schedule with given ID.
 
         :returns: schedule as dictionary, for example:
-                  {'values': [2.15, 3, 2], 'start': '2015-06-02T10:00:00+00:00', 'duration': 'PT45M', 'unit': 'MW'}
+                  {
+                      'values': [2.15, 3, 2],
+                      'start': '2015-06-02T10:00:00+00:00',
+                      'duration': 'PT45M',
+                      'unit': 'MW'
+                  }
         """
         schedule, status = await self.request(
             uri=f"sensors/{sensor_id}/schedules/{schedule_id}",
@@ -337,7 +342,12 @@ class FlexMeasuresClient:
         """Trigger a schedule and then fetch it.
 
         :returns: schedule as dictionary, for example:
-                  {'values': [2.15, 3, 2], 'start': '2015-06-02T10:00:00+00:00', 'duration': 'PT45M', 'unit': 'MW'}
+                  {
+                      'values': [2.15, 3, 2],
+                      'start': '2015-06-02T10:00:00+00:00',
+                      'duration': 'PT45M',
+                      'unit': 'MW'
+                  }
         """
         schedule_id = await self.trigger_storage_schedule(
             sensor_id=sensor_id,
@@ -370,7 +380,12 @@ class FlexMeasuresClient:
         """Post sensor data for the given time range.
 
         :returns: sensor data as dictionary, for example:
-                  {'values': [2.15, 3, 2], 'start': '2015-06-02T10:00:00+00:00', 'duration': 'PT45M', 'unit': 'MW'}
+                  {
+                      'values': [2.15, 3, 2],
+                      'start': '2015-06-02T10:00:00+00:00',
+                      'duration': 'PT45M',
+                      'unit': 'MW'
+                  }
         """
         json = dict(
             sensor=f"{entity_address}.{sensor_id}",

--- a/src/flexmeasures_client/client.py
+++ b/src/flexmeasures_client/client.py
@@ -6,7 +6,7 @@ import re
 import socket
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import Any, cast
+from typing import Any
 
 import async_timeout
 import pandas as pd
@@ -84,7 +84,7 @@ class FlexMeasuresClient:
         path: str = path,
         params: dict[str, Any] | None = None,
         include_auth: bool = True,
-    ) -> tuple[dict, int]:
+    ) -> tuple[dict | list, int]:
         """Send a request to FlexMeasures.
 
         Retries if:
@@ -134,7 +134,7 @@ class FlexMeasuresClient:
 
         check_content_type(response)
 
-        return cast(dict[str, Any], await response.json()), response.status
+        return await response.json(), response.status
 
     async def request_once(
         self,
@@ -235,7 +235,10 @@ class FlexMeasuresClient:
         production_price_sensor: int | None = None,
         inflexible_device_sensors: list[int] | None = None,
     ) -> str:
-        """Post schedule trigger with initial and target states of charge (soc)."""
+        """Post schedule trigger with initial and target states of charge (soc).
+
+        :returns: schedule ID (a UUID string)
+        """
         if not soc_targets:
             soc_targets = []
         message = {
@@ -275,16 +278,21 @@ class FlexMeasuresClient:
         check_for_status(status, 200)
         logging.info("Schedule triggered successfully.")
 
-        return response.get("schedule")
+        schedule_id: str = response.get("schedule")
+        return schedule_id
 
     async def get_schedule(
         self,
         sensor_id: int,
         schedule_id: str,
         duration: str | timedelta,
-    ):
-        """Get schedule with given ID."""
-        response, status = await self.request(
+    ) -> dict:
+        """Get schedule with given ID.
+
+        :returns: schedule as dictionary, for example:
+                  {'values': [2.15, 3, 2], 'start': '2015-06-02T10:00:00+00:00', 'duration': 'PT45M', 'unit': 'MW'}
+        """
+        schedule, status = await self.request(
             uri=f"sensors/{sensor_id}/schedules/{schedule_id}",
             method="GET",
             params={
@@ -292,20 +300,25 @@ class FlexMeasuresClient:
             },
         )
         check_for_status(status, 200)
+        return schedule
 
-        return response
+    async def get_assets(self) -> list[dict]:
+        """Get all the assets available to the current user.
 
-    async def get_assets(self):
-        """Get all the assets available to the current user"""
-        response, status = await self.request(uri="assets", method="GET")
+        :returns: list of assets as dictionaries
+        """
+        assets, status = await self.request(uri="assets", method="GET")
         check_for_status(status, 200)
-        return response
+        return assets
 
-    async def get_sensors(self):
-        """Get all the sensors available to the current user"""
-        response, status = await self.request(uri="sensors", method="GET")
+    async def get_sensors(self) -> list[dict]:
+        """Get all the sensors available to the current user.
+
+        :returns: list of sensors as dictionaries
+        """
+        sensors, status = await self.request(uri="sensors", method="GET")
         check_for_status(status, 200)
-        return response
+        return sensors
 
     async def trigger_and_get_schedule(
         self,
@@ -320,7 +333,12 @@ class FlexMeasuresClient:
         consumption_price_sensor: int | None = None,
         production_price_sensor: int | None = None,
         inflexible_device_sensors: list[int] | None = None,
-    ):
+    ) -> dict:
+        """Trigger a schedule and then fetch it.
+
+        :returns: schedule as dictionary, for example:
+                  {'values': [2.15, 3, 2], 'start': '2015-06-02T10:00:00+00:00', 'duration': 'PT45M', 'unit': 'MW'}
+        """
         schedule_id = await self.trigger_storage_schedule(
             sensor_id=sensor_id,
             start=start,
@@ -338,7 +356,6 @@ class FlexMeasuresClient:
         schedule = await self.get_schedule(
             sensor_id=sensor_id, schedule_id=schedule_id, duration=duration
         )
-
         return schedule
 
     async def get_sensor_data(
@@ -349,8 +366,12 @@ class FlexMeasuresClient:
         unit: str,
         entity_address: str,
         resolution: str | timedelta,
-    ):
-        """Post sensor data for the given time range."""
+    ) -> dict:
+        """Post sensor data for the given time range.
+
+        :returns: sensor data as dictionary, for example:
+                  {'values': [2.15, 3, 2], 'start': '2015-06-02T10:00:00+00:00', 'duration': 'PT45M', 'unit': 'MW'}
+        """
         json = dict(
             sensor=f"{entity_address}.{sensor_id}",
             start=pd.Timestamp(
@@ -365,7 +386,6 @@ class FlexMeasuresClient:
             uri="sensors/data", method="GET", params=json
         )
         check_for_status(status, 200)
-
-        print(response)
-
-        return response
+        data_fields = ("values", "start", "duration", "unit")
+        sensor_data = {k: v for k, v in response.items() if k in data_fields}
+        return sensor_data

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -366,9 +366,9 @@ async def test_get_assets() -> None:
             ],
         )
 
-        response = await flexmeasures_client.get_assets()
-        assert len(response) == 1
-        assert response[0]["account_id"] == 2
+        assets = await flexmeasures_client.get_assets()
+        assert len(assets) == 1
+        assert assets[0]["account_id"] == 2
 
     await flexmeasures_client.close()
 
@@ -395,9 +395,9 @@ async def test_get_sensors() -> None:
             ],
         )
 
-        response = await flexmeasures_client.get_sensors()
-        assert len(response) == 1
-        assert response[0]["entity_address"] == "ea1.2023-06.localhost:fm1.2"
+        sensors = await flexmeasures_client.get_sensors()
+        assert len(sensors) == 1
+        assert sensors[0]["entity_address"] == "ea1.2023-06.localhost:fm1.2"
 
     await flexmeasures_client.close()
 
@@ -520,7 +520,7 @@ async def test_get_sensor_data() -> None:
         entity_address = "ea1.2023-06.localhost:fm1"
         resolution = "PT15M"
 
-        response = await flexmeasures_client.get_sensor_data(
+        sensor_data = await flexmeasures_client.get_sensor_data(
             sensor_id=sensor_id,
             start=start,
             duration=duration,
@@ -528,6 +528,6 @@ async def test_get_sensor_data() -> None:
             entity_address=entity_address,
             resolution=resolution,
         )
-        assert response["values"] == [8.5, 8.5, 8.5]
+        assert sensor_data["values"] == [8.5, 8.5, 8.5]
 
     await flexmeasures_client.close()


### PR DESCRIPTION
Closes #15 (to be discussed).

Right now I favored basic Python types, mainly dictionaries and lists (and one instance of a string for the schedule ID), so I'm avoiding Pandas and also custom client-side Asset and Sensor classes.