### PR TITLE
Do not instantiate ClientSession already on import

### DIFF
--- a/src/flexmeasures_client/client.py
+++ b/src/flexmeasures_client/client.py
@@ -55,9 +55,11 @@ class FlexMeasuresClient:
     polling_timeout: float = POLLING_TIMEOUT  # seconds
     request_timeout: float = REQUEST_TIMEOUT  # seconds
     polling_interval: float = POLLING_INTERVAL  # seconds
-    session: ClientSession = None
+    session: ClientSession | None = None
 
     def __post_init__(self):
+        if self.session is None:
+            self.session = ClientSession()
         if not re.match(r".+\@.+\..+", self.email):
             raise EmailValidationError(
                 f"{self.email} is not an email address format string"

--- a/src/flexmeasures_client/client.py
+++ b/src/flexmeasures_client/client.py
@@ -55,7 +55,7 @@ class FlexMeasuresClient:
     polling_timeout: float = POLLING_TIMEOUT  # seconds
     request_timeout: float = REQUEST_TIMEOUT  # seconds
     polling_interval: float = POLLING_INTERVAL  # seconds
-    session: ClientSession = ClientSession()
+    session: ClientSession = None
 
     def __post_init__(self):
         if not re.match(r".+\@.+\..+", self.email):


### PR DESCRIPTION
Outside of doing actual requests, it is not a good idea, as that fails. We create the session when we need it in `start_session()`