### PR TITLE
Fix passing port number in host parameter

### DIFF
--- a/src/flexmeasures_client/client.py
+++ b/src/flexmeasures_client/client.py
@@ -86,15 +86,19 @@ class FlexMeasuresClient:
             )
         if len(self.password) < 1:
             raise EmptyPasswordError("password cannot be empty")
-        self.separate_host_and_port()
+        self.determine_port()
 
-    def separate_host_and_port(self):
+    def determine_port(self):
         parts = self.host.split(':')
-        self.host = parts[0]
         if len(parts) > 1:
+            if self.port is not None:
+                raise WrongHostError(
+                    f"Cannot set port={self.port} and also as part of host={self.host}"
+                )
             self.port = int(parts[1])
-        else:
-            self.port = 80 if self.scheme == 'http' else 443
+        elif self.port is None:
+            self.port = 443 if self.scheme == 'https' else 80
+        self.host = parts[0]
 
     async def close(self):
         """Function to close FlexMeasuresClient session when all requests are done"""

--- a/src/flexmeasures_client/client.py
+++ b/src/flexmeasures_client/client.py
@@ -46,6 +46,7 @@ class FlexMeasuresClient:
     password: str
     email: str
     host: str = "localhost:5000"
+    port: int | None = None
     ssl: bool = False
     api_version: str = API_VERSION
     path: str = f"/api/{api_version}/"
@@ -85,6 +86,12 @@ class FlexMeasuresClient:
             )
         if len(self.password) < 1:
             raise EmptyPasswordError("password cannot be empty")
+        parts = self.host.split(':')
+        self.host = parts[0]
+        if len(parts) > 1:
+            self.port = int(parts[1])
+        else:
+            self.port = 80 if self.scheme == 'http' else 443
 
     async def close(self):
         """Function to close FlexMeasuresClient session when all requests are done"""
@@ -224,7 +231,7 @@ class FlexMeasuresClient:
 
     def build_url(self, uri: str, path: str = path) -> URL:
         """Build url for request"""
-        url = URL.build(scheme=self.scheme, host=self.host, path=path).join(
+        url = URL.build(scheme=self.scheme, host=self.host, port=self.port, path=path).join(
             URL(uri),
         )
         return url

--- a/src/flexmeasures_client/client.py
+++ b/src/flexmeasures_client/client.py
@@ -95,10 +95,10 @@ class FlexMeasuresClient:
                 raise WrongHostError(
                     f"Cannot set port={self.port} and also as part of host={self.host}"
                 )
+            self.host = parts[0]
             self.port = int(parts[1])
         elif self.port is None:
             self.port = 443 if self.scheme == 'https' else 80
-        self.host = parts[0]
 
     async def close(self):
         """Function to close FlexMeasuresClient session when all requests are done"""

--- a/src/flexmeasures_client/client.py
+++ b/src/flexmeasures_client/client.py
@@ -86,6 +86,9 @@ class FlexMeasuresClient:
             )
         if len(self.password) < 1:
             raise EmptyPasswordError("password cannot be empty")
+        self.separate_host_and_port()
+
+    def separate_host_and_port(self):
         parts = self.host.split(':')
         self.host = parts[0]
         if len(parts) > 1:


### PR DESCRIPTION
Fixes #86.

To stay compatible, this plucks the port number from the host parameter (if specified).