### PR TITLE
chore: pin s2-python to dev release that uses Pydantic 1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ install_requires =
     aiohttp
     pandas
     pydantic>=1.10.8,<2.0
-    s2-python
+    s2-python==0.2.0.dev2
     async_timeout
 
 [options.packages.find]


### PR DESCRIPTION
chore: pin s2-python to dev release that uses Pydantic 1 (because HA doesn't support Pydantic 2 yet)