### PR TITLE
chore: close test clients at the end of each relevant async test

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -170,6 +170,7 @@ async def test_get_access_token() -> None:
             ssl=False,
             allow_redirects=False,
         )
+        await flexmeasures_client.close()
 
 
 @pytest.mark.asyncio
@@ -213,6 +214,7 @@ async def test_post_measurements() -> None:
             ssl=False,
             allow_redirects=False,
         )
+        await flexmeasures_client.close()
 
 
 @pytest.mark.asyncio
@@ -276,6 +278,7 @@ async def test_trigger_schedule() -> None:
             ssl=False,
             allow_redirects=False,
         )
+        await flexmeasures_client.close()
 
 
 @pytest.mark.asyncio
@@ -327,6 +330,7 @@ async def test_get_schedule_polling() -> None:
             sensor_id=1, schedule_id="some-uuid", duration="PT45M"
         )
     assert schedule["values"] == [2.15, 3, 2]
+    await flexmeasures_client.close()
 
 
 @pytest.mark.asyncio
@@ -355,6 +359,7 @@ async def test_get_schedule_timeout() -> None:
             await flexmeasures_client.get_schedule(
                 sensor_id=1, schedule_id="some-uuid", duration="PT45M"
             )
+        await flexmeasures_client.close()
 
 
 @pytest.mark.asyncio
@@ -383,6 +388,7 @@ async def test_get_assets() -> None:
         assets = await flexmeasures_client.get_assets()
         assert len(assets) == 1
         assert assets[0]["account_id"] == 2
+        await flexmeasures_client.close()
 
 
 @pytest.mark.asyncio
@@ -413,6 +419,7 @@ async def test_get_sensors() -> None:
             sensors[0]["entity_address"]
             == "ea1.1000-01.required-but-unused-field:fm1.2"
         )
+        await flexmeasures_client.close()
 
 
 @pytest.mark.asyncio
@@ -432,6 +439,7 @@ async def test_get_sensors2() -> None:
             ConnectionError, match="Error occurred while communicating with the API."
         ):
             await flexmeasures_client.get_sensors()
+        await flexmeasures_client.close()
 
 
 @pytest.mark.asyncio
@@ -493,6 +501,7 @@ async def test_trigger_and_get_schedule() -> None:
             flex_model={},
         )
     assert schedule["values"] == [2.15, 3, 2]
+    await flexmeasures_client.close()
 
 
 @pytest.mark.asyncio
@@ -530,6 +539,7 @@ async def test_get_sensor_data() -> None:
             resolution=resolution,
         )
         assert sensor_data["values"] == [8.5, 8.5, 8.5]
+        await flexmeasures_client.close()
 
 
 @pytest.mark.asyncio
@@ -564,6 +574,7 @@ async def test_reauth_with_access_token() -> None:
             json=None,
             allow_redirects=False,
         )
+        await flexmeasures_client.close()
 
 
 @pytest.mark.parametrize(
@@ -599,6 +610,7 @@ async def test_reauth_wrong_cred(email, password, payload, error) -> None:
 
         with pytest.raises(ValueError, match=error):
             await flexmeasures_client.get_sensors()
+        await flexmeasures_client.close()
 
 
 @pytest.mark.asyncio
@@ -627,6 +639,7 @@ async def test_update_sensor():
             ssl=False,
             allow_redirects=False,
         )
+        await flexmeasures_client.close()
 
 
 @pytest.mark.asyncio
@@ -655,6 +668,7 @@ async def test_update_assets():
             ssl=False,
             allow_redirects=False,
         )
+        await flexmeasures_client.close()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
When running the test suite, I got these messages:
```
===================================================================================== 31 passed in 4.87s =====================================================================================
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x7fc8f5dd9610>
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x7fc8f5d980d0>
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x7fc8f5da4310>
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x7fc8f5d03210>
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x7fc8f5dbd490>
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x7fc8f5d10e50>
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x7fc8f5b3f210>
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x7fc8f5b3d110>
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x7fc8f5b5d190>
Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x7fc8f5b4f0d0>
```
This PR closes the client at the end of each relevant test.