### PR TITLE
Feat/check server version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,6 @@ build-backend = "setuptools.build_meta"
 # For smarter version schemes and other configuration options,
 # check out https://github.com/pypa/setuptools_scm
 version_scheme = "no-guess-dev"
+
+[tool.black]
+line-length = 88

--- a/setup.cfg
+++ b/setup.cfg
@@ -114,9 +114,9 @@ formats = bdist_wheel
 [flake8]
 # Some sane defaults for the code style checker flake8
 max_line_length = 88
-extend_ignore = E203, W503
+extend_ignore = E203, E501, W503
 # ^  Black-compatible
-#    E203 and W503 have edge cases handled by black
+#    E203, E501 and W503 have edge cases handled by black
 exclude =
     .tox
     build

--- a/src/flexmeasures_client/client.py
+++ b/src/flexmeasures_client/client.py
@@ -168,7 +168,7 @@ class FlexMeasuresClient:
                     except (ClientError, socket.gaierror) as exception:
                         logging.debug(exception)
                         raise ConnectionError(
-                            "Error occurred while communicating with the API."
+                            f"Error occurred while communicating with the API: {exception}"
                         ) from exception
         except asyncio.TimeoutError as exception:
             raise ConnectionError(

--- a/src/flexmeasures_client/client.py
+++ b/src/flexmeasures_client/client.py
@@ -7,6 +7,7 @@ import re
 import socket
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from setuptools_scm import get_version
 from typing import Any, cast
 
 import async_timeout
@@ -266,7 +267,10 @@ class FlexMeasuresClient:
         self.access_token = response["auth_token"]
 
     async def get_versions(self):
-        """Get the FlexMeasures version and the supported API versions of the FlexMeasures server."""
+        """Get the FlexMeasures version and the supported API versions of the FlexMeasures server.
+
+        Also returns the client's version and the API version it uses.
+        """
         response, _status = await self.request(
             uri="",
             path="/api/",
@@ -281,7 +285,14 @@ class FlexMeasuresClient:
                 f"{self.api_version} is not supported by the FlexMeasures Server. The server supports: {server_api_versions}"
             )
 
-        return response
+        version_info = dict(
+            server_version=response.get("flexmeasures_version"),
+            server_supports_api_versions=server_api_versions,
+            client_version=get_version(),
+            client_uses_api_version=API_VERSION,
+        )
+
+        return version_info
 
     async def post_measurements(
         self,

--- a/src/flexmeasures_client/client.py
+++ b/src/flexmeasures_client/client.py
@@ -36,7 +36,7 @@ MAX_POLLING_STEPS: int = 10  # seconds
 POLLING_TIMEOUT = 200.0  # seconds
 REQUEST_TIMEOUT = 20.0  # seconds
 POLLING_INTERVAL = 10.0  # seconds
-API_VERSIONS_LIST = ("v3_0",)
+API_VERSIONS_LIST = ["v3_0"]
 
 
 @dataclass

--- a/src/flexmeasures_client/client.py
+++ b/src/flexmeasures_client/client.py
@@ -262,6 +262,24 @@ class FlexMeasuresClient:
         )
         self.access_token = response["auth_token"]
 
+    async def get_versions(self):
+        """Get the FlexMeasures version and the supported API versions of the FlexMeasures server."""
+        response, _status = await self.request(
+            uri="",
+            path="/api/",
+            method="GET",
+            include_auth=False,
+        )
+
+        # Check whether the API version used by the client is supported by the server
+        server_api_versions = response["versions"]
+        if self.api_version not in server_api_versions:
+            raise WrongAPIVersionError(
+                f"{self.api_version} is not supported by the FlexMeasures Server. The server supports: {server_api_versions}"
+            )
+
+        return response
+
     async def post_measurements(
         self,
         sensor_id: int,

--- a/src/flexmeasures_client/client.py
+++ b/src/flexmeasures_client/client.py
@@ -66,10 +66,13 @@ class FlexMeasuresClient:
             raise EmailValidationError(
                 f"{self.email} is not an email address format string"
             )
+
+        # Check whether API version is supported by the client
         if self.api_version not in API_VERSIONS_LIST:
             raise WrongAPIVersionError(
-                f"Version {self.api_version} not in versions list: {API_VERSIONS_LIST}"
+                f"{self.api_version} is not supported by the FlexMeasures Client. The client supports: {API_VERSIONS_LIST}"
             )
+
         # if ssl then scheme is https.
         if self.ssl:
             self.scheme = "https"

--- a/src/flexmeasures_client/client.py
+++ b/src/flexmeasures_client/client.py
@@ -7,13 +7,13 @@ import re
 import socket
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from packaging.version import Version
-from setuptools_scm import get_version
 from typing import Any, cast
 
 import async_timeout
 import pandas as pd
 from aiohttp.client import ClientError, ClientResponse, ClientSession
+from packaging.version import Version
+from setuptools_scm import get_version
 from yarl import URL
 
 from flexmeasures_client.constants import (

--- a/src/flexmeasures_client/client.py
+++ b/src/flexmeasures_client/client.py
@@ -13,7 +13,6 @@ import async_timeout
 import pandas as pd
 from aiohttp.client import ClientError, ClientResponse, ClientSession
 from packaging.version import Version
-from setuptools_scm import get_version
 from yarl import URL
 
 from flexmeasures_client.constants import (
@@ -286,10 +285,12 @@ class FlexMeasuresClient:
                 f"{self.api_version} is not supported by the FlexMeasures Server. The server supports: {server_api_versions}"
             )
 
+        from flexmeasures_client import __version__ as client_version
+
         version_info = dict(
             server_version=response.get("flexmeasures_version"),
             server_supports_api_versions=server_api_versions,
-            client_version=get_version(),
+            client_version=client_version,
             client_uses_api_version=API_VERSION,
         )
 

--- a/src/flexmeasures_client/response_handling.py
+++ b/src/flexmeasures_client/response_handling.py
@@ -26,6 +26,8 @@ async def check_response(
     """
     status = response.status
     payload = await response.json()
+    if payload is None:
+        payload = {}
     headers = response.headers
     if status < 300:
         pass

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -126,7 +126,7 @@ async def test__init__(
                 "password": "test_password",
             },
             WrongAPIVersionError,
-            "Version v123 not in versions list: ",
+            "v123 is not supported by the FlexMeasures Client.",
         ),
         (
             {"password": "", "email": "test@test.test"},

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -804,7 +804,11 @@ async def test_get_versions() -> None:
         m.get(
             url=url,
             status=200,
-            payload={'flexmeasures_version': '0.25.0.dev0', 'message': 'For these API versions a public endpoint is available, listing its service. For example: /api/v3_0. An authentication token can be requested at: /api/requestAuthToken', 'versions': ['v3_0']},
+            payload={
+                "flexmeasures_version": "0.25.0.dev0",
+                "message": "For these API versions a public endpoint is available, listing its service. For example: /api/v3_0. An authentication token can be requested at: /api/requestAuthToken",
+                "versions": ["v3_0"],
+            },
             repeat=True,
         )
         m.post(
@@ -818,7 +822,10 @@ async def test_get_versions() -> None:
         )
         version_info = await flexmeasures_client.get_versions()
         assert version_info["server_version"] == "0.25.0.dev0"
-        with pytest.raises(ConnectionError, match="The server runs v0.25.0.dev0, but at least v0.27.0 is required."):
+        with pytest.raises(
+            ConnectionError,
+            match="The server runs v0.25.0.dev0, but at least v0.27.0 is required.",
+        ):
             await flexmeasures_client.trigger_and_get_schedule(
                 asset_id=1,
                 start="2015-06-02T10:00:00+00:00",


### PR DESCRIPTION
Raise a more informative error if the client attempts multi-asset scheduling on a server that does not support it yet.