### PR TITLE
Enhance get_sensors() to allow filtering by asset Id

### DIFF
--- a/src/flexmeasures_client/client.py
+++ b/src/flexmeasures_client/client.py
@@ -422,12 +422,16 @@ class FlexMeasuresClient:
             )
         return assets
 
-    async def get_sensors(self) -> list[dict]:
+    async def get_sensors(self, asset_id: int | None = None) -> list[dict]:
         """Get all the sensors available to the current user.
+        Can be filtered by asset.
 
         :returns: list of sensors as dictionaries
         """
-        sensors, status = await self.request(uri="sensors", method="GET")
+        uri = "sensors"
+        if asset_id:
+            uri += f"?asset_id={asset_id}"
+        sensors, status = await self.request(uri=uri, method="GET")
         check_for_status(status, 200)
         if not isinstance(sensors, list):
             raise ContentTypeError(


### PR DESCRIPTION
Until now, the function gives a list of all sensors the user can see.

The underlying API endpoint is even more powerful (e.g. can query by account) but for now this is an atomic, highly useful extension.