### PR TITLE
fix: flex-model and flex-context are optional fields

### DIFF
--- a/src/flexmeasures_client/client.py
+++ b/src/flexmeasures_client/client.py
@@ -684,7 +684,7 @@ class FlexMeasuresClient:
             return await self.get_schedule(
                 sensor_id=sensor_id, schedule_id=schedule_id, duration=duration
             )
-        else:
+        elif flex_model is not None:
             # Get the schedule for a collection of devices (one by one)
             schedule: list[dict] = []
             for sensor_flex_model in flex_model:

--- a/src/flexmeasures_client/client.py
+++ b/src/flexmeasures_client/client.py
@@ -684,7 +684,10 @@ class FlexMeasuresClient:
             return await self.get_schedule(
                 sensor_id=sensor_id, schedule_id=schedule_id, duration=duration
             )
-        elif flex_model is not None:
+        elif flex_model is None:
+            # If there is no flex-model referencing power sensors, no power schedules are retrieved
+            return []
+        else:
             # Get the schedule for a collection of devices (one by one)
             schedule: list[dict] = []
             for sensor_flex_model in flex_model:

--- a/src/flexmeasures_client/client.py
+++ b/src/flexmeasures_client/client.py
@@ -645,8 +645,8 @@ class FlexMeasuresClient:
         self,
         start: str | datetime,
         duration: str | timedelta,
-        flex_model: dict | list[dict],
-        flex_context: dict,
+        flex_model: dict | list[dict] | None = None,
+        flex_context: dict | None = None,
         sensor_id: int | None = None,
         asset_id: int | None = None,
     ) -> dict | list[dict]:
@@ -976,8 +976,8 @@ class FlexMeasuresClient:
         self,
         start: str | datetime,
         duration: str | timedelta,
-        flex_model: dict | list[dict],
-        flex_context: dict,
+        flex_model: dict | list[dict] | None = None,
+        flex_context: dict | None = None,
         sensor_id: int | None = None,
         asset_id: int | None = None,
     ) -> str:
@@ -988,9 +988,11 @@ class FlexMeasuresClient:
                 start
             ).isoformat(),  # for example: 2021-10-13T00:00+02:00
             "duration": pd.Timedelta(duration).isoformat(),
-            "flex-model": flex_model,
-            "flex-context": flex_context,
         }
+        if flex_model is not None:
+            message["flex-model"] = flex_model
+        if flex_context is not None:
+            message["flex-context"] = flex_context
         if sensor_id is not None:
             response, status = await self.request(
                 uri=f"sensors/{sensor_id}/schedules/trigger",


### PR DESCRIPTION
If everything is defined server-side, there should be no need to pass any flex-model or flex-context in the call to the schedule triggering endpoint.