### PR TITLE
Feat/new assets api fields

### DIFF
--- a/examples/HEMS/HEMS_setup.py
+++ b/examples/HEMS/HEMS_setup.py
@@ -59,7 +59,7 @@ async def main():
         # Clean up existing assets first
         await cleanup_existing_assets(client=client, account_id=account_id)
 
-        asset: dict | None = None  # Initialize asset variable
+        asset = None  # Initialize asset variable
         assets = await client.get_assets()
         for sst in assets:
             if sst["name"] == building_name:
@@ -70,12 +70,12 @@ async def main():
             print(
                 "Creating building asset, with PV and battery sensors, and weather station"
             )
-            asset = await create_building_assets_and_sensors(client, account)
+            await create_building_assets_and_sensors(client, account)
         else:
             answer = input(f"Asset '{building_name}' already exists. Re-create?")
             if answer.lower() in ["y", "yes"]:
                 await client.delete_asset(asset_id=asset["id"])
-                asset = await create_building_assets_and_sensors(client, account)
+                await create_building_assets_and_sensors(client, account)
             else:
                 print("Assets already exist, skipping to data upload")
 
@@ -103,7 +103,7 @@ async def main():
         # Part 4: Run scheduling simulation for third week
         print("\n" + "=" * 50)
         print("PART 4: SCHEDULING SIMULATION")
-        await run_scheduling_simulation(client, asset)
+        await run_scheduling_simulation(client)
 
         # Part 5 : Create reports
         print("\n" + "=" * 50)

--- a/examples/HEMS/assets_setup.py
+++ b/examples/HEMS/assets_setup.py
@@ -681,9 +681,7 @@ async def configure_building_dashboard(
     print("Sensors to show configured successfully")
 
 
-async def create_building_assets_and_sensors(
-    client: FlexMeasuresClient, account: dict
-) -> dict:
+async def create_building_assets_and_sensors(client: FlexMeasuresClient, account: dict):
     """
     Create a building asset with its associated sensors and linked assets (PV, battery, EVSEs, and weather station),
     then configure the building's flex context and dashboard.
@@ -815,5 +813,3 @@ async def create_building_assets_and_sensors(
         daily_total_energy_costs_sensor=daily_total_energy_costs_sensor,
         daily_share_of_self_consumption_sensor=daily_share_of_self_consumption_sensor,
     )
-
-    return building_asset

--- a/examples/HEMS/scheduling.py
+++ b/examples/HEMS/scheduling.py
@@ -30,20 +30,17 @@ from flexmeasures_client.client import FlexMeasuresClient
 
 
 async def run_scheduling_simulation(
-    client: FlexMeasuresClient,
-    building_asset: dict,
-    simulate_live_corrections: bool = True,
+    client: FlexMeasuresClient, simulate_live_corrections: bool = True
 ):
     """Run step-by-step scheduling simulation for the third week with EV charging."""
     print("Running scheduling simulation for third week with EV charging...")
 
     # Find required assets and sensors
-    assets = await client.get_assets(
-        root=building_asset["id"], fields=["id", "name", "attributes"]
-    )
+    assets = await client.get_assets(fields=["id", "name", "attributes"])
 
     # Find building, battery, and EVSE assets
     assets_by_name = {a["name"]: a for a in assets}
+    building_asset = assets_by_name.get(building_name)
     battery_asset = assets_by_name.get(battery_name)
     evse1_asset = assets_by_name.get(evse1_name)
     evse2_asset = assets_by_name.get(evse2_name)


### PR DESCRIPTION
https://github.com/FlexMeasures/flexmeasures/issues/1885 made the /assets endpoint more powerful in selecting subtrees of assets and saving bandwidth.

This PR supports that in the client.

Also, it implements that the client keeps knowledge of the server version, so it can look it up for handling such cases - if the new fields are being used against an older server version than v0.31, they will not be applied but a warning is printed.

I tested this with the HEMS example (in the server, I turned `FLEXMEASURES_API_SUNSET_ACTIVE=True). I found one place where I needed to use the new `fields` parameter, and I used the `root` parameter, as well (the root asset is the building asset).