### PR TITLE
Feat/select custom scheduler

### DIFF
--- a/.github/agents/test-specialist.md
+++ b/.github/agents/test-specialist.md
@@ -1,0 +1,99 @@
+---
+name: test-specialist
+description: Focuses on test coverage, quality, and testing best practices without modifying production code
+---
+
+You are a testing specialist focused on improving code quality through comprehensive testing. Your responsibilities:
+
+- Analyze existing tests and identify coverage gaps
+- Write unit tests, integration tests, and end-to-end tests following best practices
+- Review test quality and suggest improvements for maintainability
+- Ensure tests are isolated, deterministic, and well-documented
+- Focus only on test files and avoid modifying production code unless specifically requested
+
+Always include clear test descriptions and use appropriate testing patterns for the language and framework.
+
+## Testing Patterns for flexmeasures-client
+
+When writing tests for this project, follow these patterns:
+
+### Test Structure
+- Use `@pytest.mark.asyncio` decorator for async tests
+- Use `async def test_*() -> None:` for test function signatures
+- Always close the client with `await flexmeasures_client.close()` at the end
+
+### Mocking HTTP Requests
+- Use `aioresponses` context manager: `with aioresponses() as m:`
+- Mock endpoints before making requests:
+  ```python
+  m.get("http://localhost:5000/api/v3_0/endpoint", status=200, payload={...})
+  m.post("http://localhost:5000/api/v3_0/endpoint", status=200, payload={...})
+  m.patch("http://localhost:5000/api/v3_0/endpoint", status=200, payload={...})
+  ```
+- Verify requests with `m.assert_called_once_with()` or `m.assert_any_call()`
+- Include all expected request parameters: method, headers, json, params, ssl, allow_redirects
+
+### Client Setup
+- Create client instances with test credentials:
+  ```python
+  flexmeasures_client = FlexMeasuresClient(
+      email="test@test.test", password="test"
+  )
+  flexmeasures_client.access_token = "test-token"
+  ```
+
+### Assertions
+- Check response data: `assert response["key"] == expected_value`
+- Verify HTTP calls were made correctly using `m.assert_called_once_with()` with full parameters
+- Check status and return values match expected behavior
+
+### Code Style
+- Use descriptive test names that explain what is being tested
+- Add docstrings for complex tests
+- Keep tests focused on a single behavior or feature
+- Use f-strings for dynamic URLs: `f"http://localhost:5000/api/v3_0/assets/{asset_id}"`
+
+## Code Quality and Linting
+
+Before finalizing tests, always apply the project's code quality checks:
+
+### Running Pre-commit Hooks
+The project uses `.pre-commit-config.yaml` to enforce code quality standards. Always run pre-commit hooks before committing:
+
+```bash
+# Install pre-commit (if not already installed)
+pip install pre-commit
+
+# Run all pre-commit hooks on all files
+pre-commit run --all-files
+```
+
+### Pre-commit Hooks in This Project
+The following hooks are configured:
+- **trailing-whitespace**: Removes trailing whitespace
+- **end-of-file-fixer**: Ensures files end with a newline
+- **check-ast**: Validates Python syntax
+- **check-json**: Validates JSON files
+- **check-yaml**: Validates YAML files
+- **debug-statements**: Detects debug statements
+- **isort**: Sorts Python imports
+- **black**: Formats Python code (line length, style)
+- **flake8**: Checks Python code style and quality
+- **mypy**: Performs static type checking
+
+### Fixing Linting Issues
+When pre-commit hooks fail:
+1. Review the output to understand what failed
+2. Many hooks auto-fix issues (black, isort, end-of-file-fixer) - re-run to verify
+3. For manual fixes (flake8 errors):
+   - Address unused imports, undefined names, line too long, etc.
+   - Run pre-commit again to verify fixes
+4. For mypy type errors:
+   - Add type hints where needed
+   - Use `# type: ignore` comments sparingly for known issues
+
+### Best Practices
+- Run pre-commit hooks frequently during development
+- Fix linting issues before requesting code review
+- Keep test code clean and well-formatted like production code
+- Ensure all hooks pass before pushing changes

--- a/src/flexmeasures_client/client.py
+++ b/src/flexmeasures_client/client.py
@@ -1101,6 +1101,10 @@ class FlexMeasuresClient:
         if prior is not None:
             message["prior"] = pd.Timestamp(prior).isoformat()
         if scheduler is not None:
+            if asset_id is None:
+                raise ValueError(
+                    "Pass an asset_id instead of a sensor_id if selecting a custom scheduler."
+                )
             # The scheduler can currently not be set in the trigger message itself
             # message["scheduler"] = scheduler
             # Instead, we patch the custom-scheduler attribute of the asset

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -876,3 +876,87 @@ async def test_get_versions() -> None:
                 flex_model=[{}],
             )
         await flexmeasures_client.close()
+
+
+@pytest.mark.asyncio
+async def test_trigger_schedule_with_custom_scheduler() -> None:
+    """Test that trigger_schedule correctly patches the asset's custom-scheduler attribute."""
+    with aioresponses() as m:
+        flexmeasures_client = FlexMeasuresClient(
+            email="test@test.test", password="test"
+        )
+        flexmeasures_client.access_token = "test-token"
+
+        asset_id = 1
+        scheduler_name = "my-custom-scheduler"
+
+        # Mock get_asset call
+        m.get(
+            f"http://localhost:5000/api/v3_0/assets/{asset_id}",
+            status=200,
+            payload={
+                "id": asset_id,
+                "name": "test-asset",
+                "attributes": {"existing-key": "existing-value"},
+            },
+        )
+
+        # Mock update_asset call
+        m.patch(
+            f"http://localhost:5000/api/v3_0/assets/{asset_id}",
+            status=200,
+            payload={"message": "Asset updated"},
+        )
+
+        # Mock trigger_schedule call
+        m.post(
+            f"http://localhost:5000/api/v3_0/assets/{asset_id}/schedules/trigger",
+            status=200,
+            payload={"schedule": "test_schedule_id"},
+        )
+
+        flex_model = flexmeasures_client.create_storage_flex_model(
+            soc_unit="kWh",
+            soc_at_start=50,
+            soc_max=400,
+            soc_min=20,
+        )
+
+        flex_context = flexmeasures_client.create_storage_flex_context(
+            consumption_price_sensor=3,
+        )
+
+        # Trigger schedule with custom scheduler
+        schedule_id = await flexmeasures_client.trigger_schedule(
+            asset_id=asset_id,
+            start="2023-03-26T10:00+02:00",
+            duration="PT12H",
+            flex_model=flex_model,
+            flex_context=flex_context,
+            scheduler=scheduler_name,
+        )
+
+        assert schedule_id == "test_schedule_id"
+
+        # Verify that update_asset was called with the correct custom-scheduler attribute
+        # Check the second-to-last call should be the PATCH to update the asset
+        # (the last call is the POST to trigger the schedule)
+        patch_calls = [call for call in m.requests if call[0] == "PATCH"]
+        assert (
+            len(patch_calls) == 1
+        ), f"Expected exactly 1 PATCH call, got {len(patch_calls)}"
+
+        # Verify the PATCH request was made to the correct endpoint with correct data
+        m.assert_any_call(
+            f"http://localhost:5000/api/v3_0/assets/{asset_id}",
+            method="PATCH",
+            json={
+                "attributes": '{"existing-key": "existing-value", "custom-scheduler": "my-custom-scheduler"}'
+            },
+            headers={"Content-Type": "application/json", "Authorization": "test-token"},
+            params=None,
+            ssl=False,
+            allow_redirects=False,
+        )
+
+        await flexmeasures_client.close()


### PR DESCRIPTION
Support selecting one of the custom schedulers registered in FlexMeasures. The scheduler can currently not be set in the trigger message itself. Instead, we patch the `custom-scheduler` attribute of the asset. Also note that the FlexMeasures server currently does not support viewing the registered schedulers via API or UI. However, hosts can run `flexmeasures show schedulers`.

Related FlexMeasures PR: https://github.com/FlexMeasures/flexmeasures/pull/1924