### PR TITLE
fix: reporters should find their sensors within the right community

### DIFF
--- a/examples/HEMS/HEMS_setup.py
+++ b/examples/HEMS/HEMS_setup.py
@@ -108,7 +108,9 @@ async def main(
         print("\n" + "=" * 50)
         print("PART 5: CREATING REPORTS")
         # todo B2: compute aggregate power flow for the community asset's power sensor
-        await create_reports(client, community_name=community_name, site_names=site_names)
+        await create_reports(
+            client, community_name=community_name, site_names=site_names
+        )
         print("\n" + "=" * 50)
         print("HEMS Tutorial completed successfully!")
 

--- a/examples/HEMS/reporters.py
+++ b/examples/HEMS/reporters.py
@@ -16,7 +16,9 @@ from utils.reporter_utils import fill_reporter_params, run_report_cmd
 from flexmeasures_client import FlexMeasuresClient
 
 
-async def create_reports(client: FlexMeasuresClient, community_name: str, site_names: list[str]):
+async def create_reports(
+    client: FlexMeasuresClient, community_name: str, site_names: list[str]
+):
     """Generate reports using FlexMeasures CLI."""
     print("Generating reports...")
 
@@ -48,7 +50,9 @@ async def create_reports(client: FlexMeasuresClient, community_name: str, site_n
             ),
             ("heating-power", "power", f"{heating_name} {i}"),
         ]
-        sensors = await find_sensors_by_asset(client, sensor_mappings, top_level_asset_name=community_name)
+        sensors = await find_sensors_by_asset(
+            client, sensor_mappings, top_level_asset_name=community_name
+        )
 
         # Prepare parameters for self-consumption reporter
         fill_reporter_params(


### PR DESCRIPTION
fix: reporters should find their sensors (for the JSON parameter files) only within the present community

NB: only turns up in case of running multiple communities