### PR TITLE
fix: prevent recursive JSON encoding of updates on retries

### DIFF
--- a/src/flexmeasures_client/client.py
+++ b/src/flexmeasures_client/client.py
@@ -1196,6 +1196,7 @@ class FlexMeasuresClient:
         This function raises a ValueError when an unhandled status code is returned.
         """
         uri = f"assets/{asset_id}"
+        updates = updates.copy()
         if "attributes" in updates:
             updates["attributes"] = json.dumps(updates["attributes"])
         if "flex_context" in updates:
@@ -1268,6 +1269,7 @@ class FlexMeasuresClient:
         This function raises a ValueError when an unhandled status code is returned.
         """
         uri = f"sensors/{sensor_id}"
+        updates = updates.copy()
         if "attributes" in updates:
             updates["attributes"] = json.dumps(updates["attributes"])
         updated_sensor, status = await self.request(


### PR DESCRIPTION
The `updates` dictionary was being updated in-place with each call.