### PR TITLE
feat: allow unit param in file upload

### DIFF
--- a/src/flexmeasures_client/client.py
+++ b/src/flexmeasures_client/client.py
@@ -452,11 +452,12 @@ class FlexMeasuresClient:
         self,
         sensor_id: int,
         *,
+        # Required for JSON data upload; optional for file upload
+        unit: str | None = None,
         # Parameters for JSON data upload
         start: str | datetime | None = None,
         duration: str | timedelta | None = None,
         values: list[float] | None = None,
-        unit: str | None = None,
         prior: str | datetime | None = None,
         # Parameters for file upload
         file_path: str | None = None,
@@ -467,32 +468,32 @@ class FlexMeasuresClient:
 
         This method supports two modes:
         1. JSON data upload: Provide start, duration, values, and unit parameters
-        2. File upload: Provide file_path parameter
+        2. File upload: Provide file_path and, optionally, unit parameters
 
         The method automatically chooses the appropriate API endpoint based on the provided parameters.
 
         This function raises a ValueError when an unhandled status code is returned.
         """
         # Check parameter combinations
-        json_params = [start, duration, values, unit]
+        json_params = [start, duration, values]
         has_json_params = any(param is not None for param in json_params)
         has_file_param = file_path is not None
 
         if not has_json_params and not has_file_param:
             raise ValueError(
-                "Either provide JSON data parameters (start, duration, values, unit) "
+                "Either provide JSON data parameters (start, duration, values) "
                 "or a file_path parameter, but not neither."
             )
 
         if has_json_params and has_file_param:
             raise ValueError(
-                "Either provide JSON data parameters (start, duration, values, unit) "
+                "Either provide JSON data parameters (start, duration, values) "
                 "or a file_path parameter, but not both."
             )
 
         if has_json_params:
             # Validate required JSON parameters
-            if any(param is None for param in json_params):
+            if any(param is None for param in [*json_params, unit]):
                 raise ValueError(
                     "When using JSON data upload, all parameters (start, duration, values, unit) "
                     "must be provided."
@@ -522,6 +523,7 @@ class FlexMeasuresClient:
                 sensor_id=sensor_id,
                 file_path=file_path,
                 belief_time_measured_instantly=belief_time_measured_instantly,
+                unit=unit,
             )
 
     async def _post_sensor_data_json(
@@ -561,6 +563,7 @@ class FlexMeasuresClient:
         sensor_id: int,
         file_path: str,
         belief_time_measured_instantly: bool = False,
+        unit: str | None = None,
     ):
         """
         Post sensor data using file upload.
@@ -595,6 +598,8 @@ class FlexMeasuresClient:
             "belief-time-measured-instantly",
             str(belief_time_measured_instantly),
         )
+        if unit is not None:
+            form_data.add_field("unit", unit)
         # Build URL for file upload endpoint
         url = self.build_url(f"sensors/{sensor_id}/data/upload")
 

--- a/src/flexmeasures_client/client.py
+++ b/src/flexmeasures_client/client.py
@@ -487,6 +487,14 @@ class FlexMeasuresClient:
         has_file_param = file_path is not None
 
         if not has_json_params and not has_file_param:
+            if unit is not None or prior is not None:
+                # A unit or prior on its own only makes sense for a JSON upload, so
+                # name the parameters that are missing rather than claim that
+                # nothing was provided at all.
+                raise ValueError(
+                    "When using JSON data upload, all parameters (start, duration, values, unit) "
+                    "must be provided."
+                )
             raise ValueError(
                 "Either provide JSON data parameters (start, duration, values) "
                 "or a file_path parameter, but not neither."

--- a/src/flexmeasures_client/client.py
+++ b/src/flexmeasures_client/client.py
@@ -190,17 +190,22 @@ class FlexMeasuresClient:
         """Function to close FlexMeasuresClient session when all requests are done."""
         await cast(ClientSession, self.session).close()
 
+    async def _resolve_server_version(self) -> str | None:
+        """Return the server version, looking it up if it isn't known yet."""
+        if self.server_version is None:
+            # Fall back to explicit version lookup for older servers that don't
+            # send the FlexMeasures-Version response header.
+            version_info = await self.get_versions()
+            self.server_version = version_info["server_version"]
+        return self.server_version
+
     async def ensure_minimum_server_version(
         self,
         minimum_server_version: str,
         minimum_server_version_msg: str | None = None,
     ):
         """Ensure that the server version meets a minimum requirement."""
-        if self.server_version is None:
-            # Fall back to explicit version lookup for older servers that don't
-            # send the FlexMeasures-Version response header.
-            version_info = await self.get_versions()
-            self.server_version = version_info["server_version"]
+        await self._resolve_server_version()
         if Version(cast(str, self.server_version)) < Version(minimum_server_version):
             msg = (
                 "This functionality requires FlexMeasures server of "
@@ -469,6 +474,8 @@ class FlexMeasuresClient:
         This method supports two modes:
         1. JSON data upload: Provide start, duration, values, and unit parameters
         2. File upload: Provide file_path and, optionally, unit parameters
+           (passing a unit here requires a FlexMeasures server of 0.30.0 or above,
+           as earlier servers ignore it and read the file in the sensor's own unit)
 
         The method automatically chooses the appropriate API endpoint based on the provided parameters.
 
@@ -572,6 +579,24 @@ class FlexMeasuresClient:
 
         if not os.path.exists(file_path):
             raise FileNotFoundError(f"File not found: {file_path}")
+
+        if unit is not None:
+            # Servers before v0.30.0 don't read a "unit" form field on this endpoint.
+            # They drop it silently and then ingest the file as if its values were
+            # already in the sensor's unit, returning 200 all the while. Refuse to
+            # upload rather than let unconverted values be recorded.
+            # Base versions are compared so that pre-release builds such as
+            # 0.30.0.dev5, which already expose the field, aren't rejected.
+            if not _server_version_at_least(
+                await self._resolve_server_version(), "0.30.0"
+            ):
+                raise InsufficientServerVersionError(
+                    "Uploading a file with an explicit unit requires a FlexMeasures "
+                    "server of 0.30.0 or above. Current server has version "
+                    f"{self.server_version}.\n"
+                    "Alternatively, convert the data to the sensor's unit before "
+                    "uploading, and omit the unit parameter."
+                )
 
         # Determine content type based on file extension
         file_extension = os.path.splitext(file_path)[1].lower()

--- a/tests/client/test_sensor.py
+++ b/tests/client/test_sensor.py
@@ -532,6 +532,44 @@ async def test_post_sensor_data_file_without_unit_works_on_old_server():
 
 
 @pytest.mark.asyncio
+async def test_post_sensor_data_file_unit_when_server_version_unknown():
+    """A server that reports no version can't be shown to support the unit field.
+
+    Refusing is the safe reading: a server that does not honour the unit records
+    the file's values unconverted while still answering 200.
+    """
+    csv_path = "/tmp/test_sensor_data_unknown_version.csv"
+    with open(csv_path, "w") as f:
+        f.write("datetime,value\n2023-01-01T00:00+00:00,1.0\n")
+
+    try:
+        with aioresponses() as m:
+            m.get(
+                "http://localhost:5000/api/",
+                status=200,
+                payload={"versions": ["v3_0"]},  # no flexmeasures_version key
+                repeat=True,
+            )
+            client = FlexMeasuresClient(
+                email="test@test.test", password="test", access_token="skip-auth"
+            )
+            assert client.server_version is None
+            with pytest.raises(
+                InsufficientServerVersionError,
+                match="requires a FlexMeasures server of 0.30.0 or above",
+            ):
+                await client.post_sensor_data(
+                    sensor_id=1,
+                    file_path=csv_path,
+                    unit="kW",
+                )
+            assert [key for key in m.requests if key[0] == "POST"] == []
+            await client.close()
+    finally:
+        os.unlink(csv_path)
+
+
+@pytest.mark.asyncio
 async def test_post_sensor_data_file_unit_allowed_on_dev_build():
     """A 0.30.0 pre-release already exposes the unit field, so don't reject it."""
     csv_path = "/tmp/test_sensor_data_dev_server.csv"

--- a/tests/client/test_sensor.py
+++ b/tests/client/test_sensor.py
@@ -10,6 +10,7 @@ import pytest
 from aioresponses import aioresponses
 
 from flexmeasures_client.client import ContentTypeError, FlexMeasuresClient
+from flexmeasures_client.exceptions import InsufficientServerVersionError
 
 
 @pytest.mark.asyncio
@@ -424,6 +425,7 @@ async def test_post_sensor_data_with_file():
         with aioresponses() as m:
             client = FlexMeasuresClient(email="test@test.test", password="test")
             client.access_token = "test-token"
+            client.server_version = "0.30.0"
             m.post(
                 "http://localhost:5000/api/v3_0/sensors/1/data/upload",
                 status=200,
@@ -439,6 +441,98 @@ async def test_post_sensor_data_with_file():
             form_data = request.kwargs["data"]
             fields = {field[0]["name"]: field[2] for field in form_data._fields}
             assert fields["unit"] == "kW"
+            await client.close()
+    finally:
+        os.unlink(csv_path)
+
+
+@pytest.mark.asyncio
+async def test_post_sensor_data_file_unit_requires_server_0_30():
+    """Servers before v0.30.0 silently ignore the unit, so refuse to upload at all.
+
+    Such a server would answer 200 while storing the values unconverted, as if they
+    were already in the sensor's unit.
+    """
+    csv_path = "/tmp/test_sensor_data_old_server.csv"
+    with open(csv_path, "w") as f:
+        f.write("datetime,value\n2023-01-01T00:00+00:00,1.0\n")
+
+    try:
+        with aioresponses() as m:
+            client = FlexMeasuresClient(email="test@test.test", password="test")
+            client.access_token = "test-token"
+            client.server_version = "0.29.0"
+            with pytest.raises(
+                InsufficientServerVersionError,
+                match="requires a FlexMeasures server of 0.30.0 or above",
+            ):
+                await client.post_sensor_data(
+                    sensor_id=1,
+                    file_path=csv_path,
+                    unit="kW",
+                )
+            # The upload must not have been attempted.
+            assert m.requests == {}
+            await client.close()
+    finally:
+        os.unlink(csv_path)
+
+
+@pytest.mark.asyncio
+async def test_post_sensor_data_file_without_unit_works_on_old_server():
+    """The version guard only applies when a unit is passed."""
+    csv_path = "/tmp/test_sensor_data_old_server_no_unit.csv"
+    with open(csv_path, "w") as f:
+        f.write("datetime,value\n2023-01-01T00:00+00:00,1.0\n")
+
+    try:
+        with aioresponses() as m:
+            client = FlexMeasuresClient(email="test@test.test", password="test")
+            client.access_token = "test-token"
+            client.server_version = "0.28.0"
+            m.post(
+                "http://localhost:5000/api/v3_0/sensors/1/data/upload",
+                status=200,
+                payload={"message": "Upload successful"},
+            )
+            _response_data, status = await client.post_sensor_data(
+                sensor_id=1,
+                file_path=csv_path,
+            )
+            assert status == 200
+            request = next(iter(m.requests.values()))[0]
+            fields = {
+                field[0]["name"]: field[2] for field in request.kwargs["data"]._fields
+            }
+            assert "unit" not in fields
+            await client.close()
+    finally:
+        os.unlink(csv_path)
+
+
+@pytest.mark.asyncio
+async def test_post_sensor_data_file_unit_allowed_on_dev_build():
+    """A 0.30.0 pre-release already exposes the unit field, so don't reject it."""
+    csv_path = "/tmp/test_sensor_data_dev_server.csv"
+    with open(csv_path, "w") as f:
+        f.write("datetime,value\n2023-01-01T00:00+00:00,1.0\n")
+
+    try:
+        with aioresponses() as m:
+            client = FlexMeasuresClient(email="test@test.test", password="test")
+            client.access_token = "test-token"
+            client.server_version = "0.30.0.dev5"
+            m.post(
+                "http://localhost:5000/api/v3_0/sensors/1/data/upload",
+                status=200,
+                payload={"message": "Upload successful"},
+            )
+            _response_data, status = await client.post_sensor_data(
+                sensor_id=1,
+                file_path=csv_path,
+                unit="kW",
+            )
+            assert status == 200
             await client.close()
     finally:
         os.unlink(csv_path)

--- a/tests/client/test_sensor.py
+++ b/tests/client/test_sensor.py
@@ -376,7 +376,7 @@ async def test_post_sensor_data_no_params():
     client = FlexMeasuresClient(email="test@test.test", password="test")
     with pytest.raises(
         ValueError,
-        match="Either provide JSON data parameters \\(start, duration, values, unit\\) or a file_path parameter, but not neither\\.",
+        match="Either provide JSON data parameters \\(start, duration, values\\) or a file_path parameter, but not neither\\.",
     ):
         await client.post_sensor_data(sensor_id=1)
     await client.close()
@@ -388,7 +388,7 @@ async def test_post_sensor_data_both_params():
     client = FlexMeasuresClient(email="test@test.test", password="test")
     with pytest.raises(
         ValueError,
-        match="Either provide JSON data parameters \\(start, duration, values, unit\\) or a file_path parameter, but not both\\.",
+        match="Either provide JSON data parameters \\(start, duration, values\\) or a file_path parameter, but not both\\.",
     ):
         await client.post_sensor_data(
             sensor_id=1,
@@ -415,7 +415,7 @@ async def test_post_sensor_data_partial_params():
 
 @pytest.mark.asyncio
 async def test_post_sensor_data_with_file():
-    """file_path provided triggers file upload endpoint."""
+    """file_path provided triggers file upload endpoint and accepts a unit."""
     csv_path = "/tmp/test_sensor_data.csv"
     with open(csv_path, "w") as f:
         f.write("datetime,value\n2023-01-01T00:00+00:00,1.0\n")
@@ -432,8 +432,13 @@ async def test_post_sensor_data_with_file():
             response_data, status = await client.post_sensor_data(
                 sensor_id=1,
                 file_path=csv_path,
+                unit="kW",
             )
             assert status == 200
+            request = next(iter(m.requests.values()))[0]
+            form_data = request.kwargs["data"]
+            fields = {field[0]["name"]: field[2] for field in form_data._fields}
+            assert fields["unit"] == "kW"
             await client.close()
     finally:
         os.unlink(csv_path)

--- a/tests/client/test_sensor.py
+++ b/tests/client/test_sensor.py
@@ -415,6 +415,27 @@ async def test_post_sensor_data_partial_params():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"unit": "MW"},
+        {"prior": "2023-01-01T00:00+00:00"},
+        {"unit": "MW", "prior": "2023-01-01T00:00+00:00"},
+    ],
+)
+async def test_post_sensor_data_only_unit_or_prior(kwargs):
+    """A lone unit/prior points at the missing params, not at "you passed nothing".
+
+    Neither counts towards has_json_params, but reporting that neither mode was
+    chosen is misleading when the caller clearly attempted a JSON upload.
+    """
+    client = FlexMeasuresClient(email="test@test.test", password="test")
+    with pytest.raises(ValueError, match="all parameters .* must be provided"):
+        await client.post_sensor_data(sensor_id=1, **kwargs)
+    await client.close()
+
+
+@pytest.mark.asyncio
 async def test_post_sensor_data_with_file():
     """file_path provided triggers file upload endpoint and accepts a unit."""
     csv_path = "/tmp/test_sensor_data.csv"


### PR DESCRIPTION
The file upload (via `post_sensor_data()` and `_post_sensor_data_file()`) should allow to specify the unit parameter.  The former accepts a unit param but only uses it for JSON upload.

This PR adds this missing ability.